### PR TITLE
make `drive_file.comment` larger

### DIFF
--- a/packages/backend/migration/1680969937000-larger-image-comment.js
+++ b/packages/backend/migration/1680969937000-larger-image-comment.js
@@ -1,0 +1,12 @@
+export class largerImageComment1680969937000 {
+    name = 'largerImageComment1680969937000';
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "drive_file" ALTER COLUMN "comment" TYPE character varying(8192)`, undefined);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "drive_file" ALTER COLUMN "comment" TYPE character varying(512)`, undefined);
+    }
+
+}

--- a/packages/backend/src/const.ts
+++ b/packages/backend/src/const.ts
@@ -21,7 +21,7 @@ export const DB_MAX_NOTE_TEXT_LENGTH = 8192;
  * Maximum image description length that can be stored in DB.
  * Surrogate pairs count as one
  */
-export const DB_MAX_IMAGE_COMMENT_LENGTH = 512;
+export const DB_MAX_IMAGE_COMMENT_LENGTH = 8192;
 //#endregion
 
 // ブラウザで直接表示することを許可するファイルの種類のリスト

--- a/packages/backend/src/models/DriveFile.ts
+++ b/packages/backend/src/models/DriveFile.ts
@@ -67,7 +67,8 @@ export class MiDriveFile {
 	public size: number;
 
 	@Column('varchar', {
-		length: 512, nullable: true,
+		length: 8192,
+		nullable: true,
 		comment: 'The comment of the DriveFile.',
 	})
 	public comment: string | null;

--- a/packages/backend/src/server/api/endpoints/drive/files/update.ts
+++ b/packages/backend/src/server/api/endpoints/drive/files/update.ts
@@ -10,6 +10,7 @@ import { DI } from '@/di-symbols.js';
 import { RoleService } from '@/core/RoleService.js';
 import { DriveService } from '@/core/DriveService.js';
 import { ApiError } from '../../../error.js';
+import { DB_MAX_IMAGE_COMMENT_LENGTH } from '@/const.js';
 
 export const meta = {
 	tags: ['drive'],
@@ -65,7 +66,7 @@ export const paramDef = {
 		folderId: { type: 'string', format: 'misskey:id', nullable: true },
 		name: { type: 'string' },
 		isSensitive: { type: 'boolean' },
-		comment: { type: 'string', nullable: true, maxLength: 512 },
+		comment: { type: 'string', nullable: true, maxLength: DB_MAX_IMAGE_COMMENT_LENGTH },
 	},
 	required: ['fileId'],
 } as const;

--- a/packages/backend/src/server/api/endpoints/drive/files/upload-from-url.ts
+++ b/packages/backend/src/server/api/endpoints/drive/files/upload-from-url.ts
@@ -9,6 +9,7 @@ import { Endpoint } from '@/server/api/endpoint-base.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { DriveFileEntityService } from '@/core/entities/DriveFileEntityService.js';
 import { DriveService } from '@/core/DriveService.js';
+import { DB_MAX_IMAGE_COMMENT_LENGTH } from '@/const.js';
 
 export const meta = {
 	tags: ['drive'],
@@ -33,7 +34,7 @@ export const paramDef = {
 		url: { type: 'string' },
 		folderId: { type: 'string', format: 'misskey:id', nullable: true, default: null },
 		isSensitive: { type: 'boolean', default: false },
-		comment: { type: 'string', nullable: true, maxLength: 512, default: null },
+		comment: { type: 'string', nullable: true, maxLength: DB_MAX_IMAGE_COMMENT_LENGTH, default: null },
 		marker: { type: 'string', nullable: true, default: null },
 		force: { type: 'boolean', default: false },
 	},


### PR DESCRIPTION
## What

This change allows us to accept and produce longer alt-text for attachments.

## Why

512 characters are a bit too short. For example, https://mastodon.social/@nocontexttrek often has alt-text longer than 512 characters, and I also have written longer image descriptions.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
