### PR TITLE
upd: partially un-hash CSS class names

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -83,11 +83,8 @@ export function getConfig(): UserConfig {
 			modules: {
 				generateScopedName(name, filename, _css): string {
 					const id = (path.relative(__dirname, filename.split('?')[0]) + '-' + name).replace(/[\\\/\.\?&=]/g, '-').replace(/(src-|vue-)/g, '');
-					if (process.env.NODE_ENV === 'production') {
-						return 'x' + toBase62(hash(id)).substring(0, 4);
-					} else {
-						return id;
-					}
+					const shortId = id.replace(/^(components(-global)?|widgets|ui(-_common_)?)-/, '');
+					return shortId + '-' + toBase62(hash(id)).substring(0, 4);
 				},
 			},
 		},


### PR DESCRIPTION
intended to allow easier creation of custom CSS modifications. the last 4 chars of class names should be static as long as files don't move, but just in case modifications might prefer to use prefix selectors such as [class^=MkWhatever] instead of .MkWhatever-1234