### PR TITLE
feat: allow using wildcards in antenna

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -402,7 +402,7 @@ antennaKeywordsDescription: "Separate with spaces for an AND condition or with l
 notifyAntenna: "Notify about new notes"
 withFileAntenna: "Only notes with files"
 enableServiceworker: "Enable Push-Notifications for your Browser"
-antennaUsersDescription: "List one username per line"
+antennaUsersDescription: "List one username per line. Use \"*@instance.com\" to specify all users of an instance"
 caseSensitive: "Case sensitive"
 withReplies: "Include replies"
 connectedTo: "Following account(s) are connected"

--- a/locales/es-ES.yml
+++ b/locales/es-ES.yml
@@ -391,7 +391,7 @@ antennaKeywordsDescription: "Separar con espacios es una declaración AND, separ
 notifyAntenna: "Notificar nueva nota"
 withFileAntenna: "Sólo notas con archivos adjuntados"
 enableServiceworker: "Activar ServiceWorker"
-antennaUsersDescription: "Elegir nombres de usuarios separados por una linea nueva"
+antennaUsersDescription: "Elegir nombres de usuarios separados por una linea nueva. Utilice \"*@instance.com\" para especificar todos los usuarios de una instancia."
 caseSensitive: "Distinguir mayúsculas de minúsculas"
 withReplies: "Incluir respuestas"
 connectedTo: "Estas cuentas están conectadas"

--- a/packages/backend/src/core/AntennaService.ts
+++ b/packages/backend/src/core/AntennaService.ts
@@ -115,13 +115,17 @@ export class AntennaService implements OnApplicationShutdown {
 				const { username, host } = Acct.parse(x);
 				return this.utilityService.getFullApAccount(username, host).toLowerCase();
 			});
-			if (!accts.includes(this.utilityService.getFullApAccount(noteUser.username, noteUser.host).toLowerCase())) return false;
+			const matchUser = this.utilityService.getFullApAccount(noteUser.username, noteUser.host).toLowerCase();
+			const matchWildcard = this.utilityService.getFullApAccount('*', noteUser.host).toLowerCase();
+			if (!accts.includes(matchUser) && !accts.includes(matchWildcard)) return false;
 		} else if (antenna.src === 'users_blacklist') {
 			const accts = antenna.users.map(x => {
 				const { username, host } = Acct.parse(x);
 				return this.utilityService.getFullApAccount(username, host).toLowerCase();
 			});
-			if (accts.includes(this.utilityService.getFullApAccount(noteUser.username, noteUser.host).toLowerCase())) return false;
+			const matchUser = this.utilityService.getFullApAccount(noteUser.username, noteUser.host).toLowerCase();
+			const matchWildcard = this.utilityService.getFullApAccount('*', noteUser.host).toLowerCase();
+			if (accts.includes(matchUser) || accts.includes(matchWildcard)) return false;
 		}
 
 		const keywords = antenna.keywords


### PR DESCRIPTION
## What
This adds the ability to specify wildcard in the user portion of account names when using the user or user blacklist feature of antennas.

## Why
Currently when creating antenna you do not have the ability to restrict to a single instance or to block a single instance from the matched notes, which can be useful when trying to narrow down the notes that appear in the antenna results.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
