### PR TITLE
some small ui tweaks

### DIFF
--- a/packages/frontend/src/components/MkDateSeparatedList.vue
+++ b/packages/frontend/src/components/MkDateSeparatedList.vue
@@ -178,6 +178,8 @@ export default defineComponent({
 }
 
 .date-separated-list-nogap {
+	border-radius: var(--radius);
+
 	> * {
 		margin: 0 !important;
 		border: none;

--- a/packages/frontend/src/components/MkMediaList.vue
+++ b/packages/frontend/src/components/MkMediaList.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div ref="root">
+<div ref="root" :class="$style.root">
 	<XBanner v-for="media in mediaList.filter(media => !previewable(media))" :key="media.id" :media="media"/>
 	<div v-if="mediaList.filter(media => previewable(media)).length > 0" :class="$style.container">
 		<div
@@ -260,6 +260,10 @@ const previewable = (file: Misskey.entities.DriveFile): boolean => {
 </script>
 
 <style lang="scss" module>
+.root {
+	cursor: auto; /* not clickToOpen-able */
+}
+
 .container {
 	position: relative;
 	width: 100%;

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -49,7 +49,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	<article v-else :class="$style.article" @contextmenu.stop="onContextmenu">
 		<div v-if="appearNote.channel" :class="$style.colorBar" :style="{ background: appearNote.channel.color }"></div>
 		<MkAvatar :class="$style.avatar" :user="appearNote.user" link preview/>
-		<div :class="$style.main" @click="defaultStore.state.clickToOpen ? noteclick(appearNote.id) : undefined">
+		<div :class="[$style.main, { [$style.clickToOpen]: defaultStore.state.clickToOpen }]" @click="defaultStore.state.clickToOpen ? noteclick(appearNote.id) : undefined">
 			<MkNoteHeader :note="appearNote" :mini="true" v-on:click.stop/>
 			<MkInstanceTicker v-if="showTicker" :instance="appearNote.user.instance"/>
 			<div style="container-type: inline-size;">
@@ -852,7 +852,6 @@ function readPromo() {
 }
 
 .cw {
-	cursor: default;
 	display: block;
 	margin: 0;
 	padding: 0;
@@ -1095,5 +1094,9 @@ function readPromo() {
 	margin: 2px;
 	padding: 0 6px;
 	opacity: .8;
+}
+
+.clickToOpen {
+	cursor: pointer;
 }
 </style>

--- a/packages/frontend/src/components/MkNoteHeader.vue
+++ b/packages/frontend/src/components/MkNoteHeader.vue
@@ -56,6 +56,7 @@ async function menuVersions(viaKeyboard = false): Promise<void> {
 	display: flex;
 	align-items: baseline;
 	white-space: nowrap;
+	cursor: auto; /* not clickToOpen-able */
 }
 
 .name {

--- a/packages/frontend/src/components/MkNoteSimple.vue
+++ b/packages/frontend/src/components/MkNoteSimple.vue
@@ -73,7 +73,6 @@ watch(() => props.expandAllCws, (expandAllCws) => {
 }
 
 .cw {
-	cursor: default;
 	display: block;
 	margin: 0;
 	padding: 0;

--- a/packages/frontend/src/components/MkNoteSub.vue
+++ b/packages/frontend/src/components/MkNoteSub.vue
@@ -478,7 +478,6 @@ if (props.detail) {
 }
 
 .cw {
-	cursor: default;
 	display: block;
 	margin: 0;
 	padding: 0;

--- a/packages/frontend/src/components/MkNotes.vue
+++ b/packages/frontend/src/components/MkNotes.vue
@@ -55,6 +55,8 @@ defineExpose({
 <style lang="scss" module>
 .root {
 	&.noGap {
+		border-radius: var(--radius);
+
 		> .notes {
 			background: color-mix(in srgb, var(--panel) 65%, transparent);
 		}

--- a/packages/frontend/src/components/MkReactionsViewer.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.vue
@@ -86,6 +86,7 @@ watch([() => props.note.reactions, () => props.maxNumber], ([newSource, maxNumbe
 
 .root {
 	margin: 4px -2px 0 -2px;
+	cursor: auto; /* not clickToOpen-able */
 
 	&:empty {
 		display: none;

--- a/packages/frontend/src/components/MkSubNoteContent.vue
+++ b/packages/frontend/src/components/MkSubNoteContent.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <div :class="[$style.root, { [$style.collapsed]: collapsed }]">
-	<div @click="defaultStore.state.clickToOpen ? noteclick(note.id) : undefined">
+	<div :class="{ [$style.clickToOpen]: defaultStore.state.clickToOpen }" @click="defaultStore.state.clickToOpen ? noteclick(note.id) : undefined">
 		<span v-if="note.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
 		<span v-if="note.deletedAt" style="opacity: 0.5">({{ i18n.ts.deleted }})</span>
 		<MkA v-if="note.replyId" :class="$style.reply" :to="`/notes/${note.replyId}`" v-on:click.stop><i class="ph-arrow-bend-left-up ph-bold pg-lg"></i></MkA>
@@ -133,5 +133,9 @@ const collapsed = $ref(isLong);
 	font-size: 0.8em;
 	border-radius: var(--radius-ellipse);
 	box-shadow: 0 2px 6px rgb(0 0 0 / 20%);
+}
+
+.clickToOpen {
+	cursor: pointer;
 }
 </style>

--- a/packages/frontend/src/components/global/MkAvatar.vue
+++ b/packages/frontend/src/components/global/MkAvatar.vue
@@ -169,7 +169,7 @@ watch(() => props.user.avatarBlurhash, () => {
 	left: 0;
 	right: 0;
 	top: 0;
-	border-radius: var(--radius-full);
+	border-radius: 100%;
 	z-index: 1;
 	overflow: clip;
 	object-fit: cover;

--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -520,7 +520,7 @@ onUnmounted(() => {
 					z-index: 2;
 					width: 120px;
 					height: 120px;
-					box-shadow: 1px 1px 3px rgba(#000, 0.2);
+					filter: drop-shadow(1px 1px 3px rgba(#000, 0.2));
 				}
 
 				> .roles {


### PR DESCRIPTION
* rounded timeline corners when "Show a gap between posts on the timeline" is disabled
* show a pointer cursor when hovering over clickable parts of notes when "Click to open notes" is enabled
* hide status indicators when they're in an "unknown" state
* add more shadows

<details>
<summary>before</summary>

![Screenshot 2023-10-30 at 15-19-55 @kopper](https://github.com/transfem-org/Sharkey/assets/106974765/933ad4d4-a5ec-423b-97a6-1e9d7f9b775d)
</details>

<details>
<summary>after</summary>

![Screenshot 2023-10-30 at 15-18-42 @kopper](https://github.com/transfem-org/Sharkey/assets/106974765/a2692382-001c-419c-a157-7be164c21e4e)
</details>

there are three parts of this pr i'm not too sure on:

* i directly copied the ._shadow helper's box-shadow definition for consistency, but i'm not entirely sure if the size of those shadows fit the ui. it may make sense to play with the individual shadow sizes
    * imo it's still better than having no separation between the elements and the background
* 4fcd47bf087480b3ee731eff4d24f5de2b40fe29 feels a bit too "fragile" as i just apply a shadow to all panel elements no matter what. so far there is only one obvious exception i could find that needed reverting (notifications), but there's probably more out there i haven't encountered. unsure about that commit.
    * that said, individually hunting down parts that could use a shadow in a codebase as large as misskey feels like a tiring job, so not sure on what the best way to approach that would be
* pnpm lint runs out of memory in my laptop