### PR TITLE
try to fix #118

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/notes.ts
+++ b/packages/backend/src/server/api/endpoints/users/notes.ts
@@ -123,6 +123,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 							}
 						}
 
+						if (ps.withFiles && !note.fileIds) return false;
+
 						if (note.channel?.isSensitive && !isSelf) return false;
 						if (note.visibility === 'specified' && (!me || (me.id !== note.userId && !note.visibleUserIds.some(v => v === me.id)))) return false;
 						if (note.visibility === 'followers' && !isFollowing && !isSelf) return false;

--- a/packages/backend/src/server/api/endpoints/users/notes.ts
+++ b/packages/backend/src/server/api/endpoints/users/notes.ts
@@ -123,7 +123,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 							}
 						}
 
-						if (ps.withFiles && !note.fileIds) return false;
+						if (ps.withFiles && note.fileIds.length === 0) return false;
 
 						if (note.channel?.isSensitive && !isSelf) return false;
 						if (note.visibility === 'specified' && (!me || (me.id !== note.userId && !note.visibleUserIds.some(v => v === me.id)))) return false;


### PR DESCRIPTION
when fetching notes from Redis, we need to re-check the criteria from the API request, because `userTimelineWithFiles`,
`userTimelineWithReplies`, `userTimelineWithChannel` all get merged together, so `noteIds` may well contain notes without attachments…

thanks to @codingneko for reporting the bug

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
