### PR TITLE
always preserve old text when editing a note

### DIFF
--- a/packages/backend/src/core/NoteEditService.ts
+++ b/packages/backend/src/core/NoteEditService.ts
@@ -393,7 +393,7 @@ export class NoteEditService implements OnApplicationShutdown {
 			await this.noteEditRepository.insert({
 				id: this.idService.gen(),
 				noteId: oldnote.id,
-				oldText: update.text ? oldnote.text : undefined,
+				oldText: oldnote.text || undefined,
 				newText: update.text || undefined,
 				cw: update.cw || undefined,
 				fileIds: undefined,


### PR DESCRIPTION
before this change:

* create a note, with text
  * `note` has a row with the text
  * `note_edit` doesn't have any matching row
* edit the note, removing all the text
  * the row in `note` has the new, empty, text
  * `note_edit` has a matching row, but its `oldText` is NULL

so the original text is lost

after this change, the row in `note_edit` always keeps the previous text

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
