### PR TITLE
improve recreateChain

### DIFF
--- a/packages/backend/src/queue/processors/ImportNotesProcessorService.ts
+++ b/packages/backend/src/queue/processors/ImportNotesProcessorService.ts
@@ -71,49 +71,38 @@ export class ImportNotesProcessorService {
 
 	// Function was taken from Firefish and edited to remove renoteId and make it run in only one for loop instead of two
 	@bindThis
-	private async recreateChain(arr: any[]) {
+	private async recreateChain(idField: string, replyField: string, arr: any[]): Promise<any[]> {
 		type NotesMap = {
 			[id: string]: any;
 		};
 		const notesTree: any[] = [];
-		const lookup: NotesMap = {};
+		const noteById: NotesMap = {};
+		const notesWaitingForParent: NotesMap = {};
+
 		for await (const note of arr) {
-			lookup[`${note.id}`] = note;
+			noteById[note[idField]] = note;
 			note.childNotes = [];
-			let parent = null;
-			
-			if (note.replyId == null) {
+
+			const children = notesWaitingForParent[note[idField]];
+			if (children) {
+				note.childNotes.push(...children);
+			}
+
+			if (note[replyField] == null) {
 				notesTree.push(note);
-			} else {
-				parent = lookup[`${note.replyId}`];
+				continue;
 			}
 
-			if (parent) parent.childNotes.push(note);
+			const parent = noteById[note[replyField]];
+			if (parent) {
+				parent.childNotes.push(note);
+			} else {
+				notesWaitingForParent[note[replyField]] ||= [];
+				notesWaitingForParent[note[replyField]].push(note);
+			}
 		}
+
 		return notesTree;
-	}
-
-	@bindThis
-	private async recreateTwitChain(arr: any[]) {
-		type TweetsMap = {
-			[id: string]: any;
-		};
-		const tweetsTree: any[] = [];
-		const lookup: TweetsMap = {};
-		for await (const tweet of arr) {
-			lookup[`${tweet.id_str}`] = tweet;
-			tweet.replies = [];
-			let parent = null;
-			
-			if (!tweet.in_reply_to_status_id_str) {
-				tweetsTree.push(tweet);
-			} else {
-				parent = lookup[`${tweet.in_reply_to_status_id_str}`];
-			}
-
-			if (parent) parent.replies.push(tweet);
-		}
-		return tweetsTree;
 	}
 
 	@bindThis
@@ -178,9 +167,7 @@ export class ImportNotesProcessorService {
 				const tweets = Object.keys(fakeWindow.window.YTD.tweets.part0).reduce((m, key, i, obj) => {
 					return m.concat(fakeWindow.window.YTD.tweets.part0[key].tweet);
 				}, []);
-				// Due to the way twitter outputs the tweets the entire array needs to be reversed for the recreate function.
-				const reversedTweets = tweets.reverse();
-				const processedTweets = await this.recreateTwitChain(reversedTweets);
+				const processedTweets = await this.recreateChain("id_str", "in_reply_to_status_id_str", tweets);
 				this.queueService.createImportTweetsToDbJob(job.data.user, processedTweets, null);
 			} finally {
 				cleanup();
@@ -248,7 +235,7 @@ export class ImportNotesProcessorService {
 
 			const notesJson = fs.readFileSync(path, 'utf-8');
 			const notes = JSON.parse(notesJson);
-			const processedNotes = await this.recreateChain(notes);
+			const processedNotes = await this.recreateChain("id", "replyId", notes);
 			this.queueService.createImportKeyNotesToDbJob(job.data.user, processedNotes, null);
 			cleanup();
 		}
@@ -484,9 +471,9 @@ export class ImportNotesProcessorService {
 		try {
 			const date = new Date(tweet.created_at);
 			const textReplaceURLs = tweet.entities.urls && tweet.entities.urls.length > 0 ? await replaceTwitterUrls(tweet.full_text, tweet.entities.urls) : tweet.full_text;
-			const text = tweet.entities.user_mentions && tweet.entities.user_mentions.length > 0 ? await replaceTwitterMentions(textReplaceURLs, tweet.entities.user_mentions) : textReplaceURLs; 
+			const text = tweet.entities.user_mentions && tweet.entities.user_mentions.length > 0 ? await replaceTwitterMentions(textReplaceURLs, tweet.entities.user_mentions) : textReplaceURLs;
 			const files: MiDriveFile[] = [];
-			
+
 			if (tweet.extended_entities && this.isIterable(tweet.extended_entities.media)) {
 				for await (const file of tweet.extended_entities.media) {
 					if (file.video_info) {
@@ -543,7 +530,7 @@ export class ImportNotesProcessorService {
 				}
 			}
 			const createdNote = await this.noteCreateService.import(user, { createdAt: date, reply: parentNote, text: text, files: files });
-			if (tweet.replies) this.queueService.createImportTweetsToDbJob(user, tweet.replies, createdNote.id);
+			if (tweet.childNotes) this.queueService.createImportTweetsToDbJob(user, tweet.childNotes, createdNote.id);
 		} catch (e) {
 			this.logger.warn(`Error: ${e}`);
 		}

--- a/packages/frontend/src/pages/auth.vue
+++ b/packages/frontend/src/pages/auth.vue
@@ -84,6 +84,8 @@ function accepted() {
 		if (session.app.callbackUrl.includes('public-api.wordpress.com')) {
 			callbackUrl.searchParams.append('action', 'verify');
 			callbackUrl.searchParams.append('service', 'mastodon');
+			callbackUrl.searchParams.append('kr_nonce', wordpress.get('kr_nonce') as string);
+			callbackUrl.searchParams.append('nonce', wordpress.get('nonce') as string);
 		}
 		location.href = callbackUrl.toString();
 	} else if (session && session.app.callbackUrl) {

--- a/packages/frontend/src/pages/auth.vue
+++ b/packages/frontend/src/pages/auth.vue
@@ -77,10 +77,14 @@ function accepted() {
 			state = "fetch-session-error";
 			throw new Error("Callback URI doesn't match registered app");
 		}
-		const test = new URLSearchParams(window.location.search);
-		const callbackUrl = session.app.callbackUrl.includes('elk.zone') ? new URL(session.app.callbackUrl) : session.app.callbackUrl.includes('wordpress.com') ? new URL(test.get('redirect_uri') as string) : new URL(redirectUri);
+		const wordpress = new URLSearchParams(window.location.search);
+		const callbackUrl = session.app.callbackUrl.includes('elk.zone') ? new URL(session.app.callbackUrl) : session.app.callbackUrl.includes('wordpress.com') ? new URL(wordpress.get('redirect_uri') as string) : new URL(redirectUri);
 		callbackUrl.searchParams.append("code", session.token);
 		if (getUrlParams().state) callbackUrl.searchParams.append("state", getUrlParams().state);
+		if (session.app.callbackUrl.includes('public-api.wordpress.com')) {
+			callbackUrl.searchParams.append('action', 'verify');
+			callbackUrl.searchParams.append('service', 'mastodon');
+		}
 		location.href = callbackUrl.toString();
 	} else if (session && session.app.callbackUrl) {
 		const url = new URL(session.app.callbackUrl);

--- a/packages/frontend/src/pages/auth.vue
+++ b/packages/frontend/src/pages/auth.vue
@@ -73,7 +73,7 @@ function accepted() {
 	const isMastodon = !!getUrlParams().mastodon;
 	if (session && session.app.callbackUrl && isMastodon) {
 		const redirectUri = decodeURIComponent(getUrlParams().redirect_uri);
-		if (!session.app.callbackUrl.includes('elk.zone') && !session.app.callbackUrl.split("\n").includes(redirectUri)) {
+		if (!session.app.callbackUrl.includes('elk.zone') && !session.app.callbackUrl.includes('public-api.wordpress.com') && !session.app.callbackUrl.split("\n").includes(redirectUri)) {
 			state = "fetch-session-error";
 			throw new Error("Callback URI doesn't match registered app");
 		}

--- a/packages/frontend/src/pages/auth.vue
+++ b/packages/frontend/src/pages/auth.vue
@@ -77,7 +77,8 @@ function accepted() {
 			state = "fetch-session-error";
 			throw new Error("Callback URI doesn't match registered app");
 		}
-		const callbackUrl = session.app.callbackUrl.includes('elk.zone') ? new URL(session.app.callbackUrl) : new URL(redirectUri);
+		const test = new URLSearchParams(window.location.search);
+		const callbackUrl = session.app.callbackUrl.includes('elk.zone') ? new URL(session.app.callbackUrl) : session.app.callbackUrl.includes('wordpress.com') ? new URL(test.get('redirect_uri') as string) : new URL(redirectUri);
 		callbackUrl.searchParams.append("code", session.token);
 		if (getUrlParams().state) callbackUrl.searchParams.append("state", getUrlParams().state);
 		location.href = callbackUrl.toString();


### PR DESCRIPTION
* it no longer cares about the order of the notes in the input array, it will always match parent and children
* a single function can process notes and tweets, because it takes the id + replyid field names as arguments
* the same function should be usable for other importers, too

I had to pick a single field name between `replies` and `childNotes`, I picked `childNotes` and updated the tweet import job code to match.

This code imported correctly my Twitter export:
![Screenshot 2023-11-18 at 10-52-38 Misskey](https://github.com/transfem-org/Sharkey/assets/86328/5ea4012d-4882-453a-b835-1c5e2f82891a)
and my Sharkey export:
![Screenshot 2023-11-18 at 10-59-30 Misskey](https://github.com/transfem-org/Sharkey/assets/86328/704a265c-dc69-405f-805b-efa489e3f6c7)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
