### PR TITLE
add missing bits to docker example config

### DIFF
--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -112,6 +112,7 @@ redis:
 #  apiKey: ''
 #  ssl: true
 #  index: ''
+#  scope: global
 
 #   ┌───────────────┐
 #───┘ ID generation └───────────────────────────────────────────
@@ -144,14 +145,21 @@ id: 'aidx'
 # Job concurrency per worker
 # deliverJobConcurrency: 128
 # inboxJobConcurrency: 16
+# relashionshipJobConcurrency: 16
+#  What's relashionshipJob?:
+#   Follow, unfollow, block and unblock(ings) while following-imports, etc. or account migrations.
 
 # Job rate limiter
 # deliverJobPerSec: 128
 # inboxJobPerSec: 16
+# relashionshipJobPerSec: 64
 
 # Job attempts
 # deliverJobMaxAttempts: 12
 # inboxJobMaxAttempts: 8
+
+# Local address used for outgoing requests
+#outgoingAddress: 127.0.0.1
 
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4
@@ -175,7 +183,14 @@ proxyBypassHosts:
 #mediaProxy: https://example.com/proxy
 
 # Proxy remote files (default: true)
+# Proxy remote files by this instance or mediaProxy to prevent remote files from running in remote domains.
 proxyRemoteFiles: true
+
+# Movie Thumbnail Generation URL
+# There is no reference implementation.
+# For example, Misskey will point to the following URL:
+#   https://example.com/thumbnail.webp?thumbnail=1&url=https%3A%2F%2Fstorage.example.com%2Fpath%2Fto%2Fvideo.mp4
+#videoThumbnailGenerator: https://example.com
 
 # Sign to ActivityPub GET request (default: true)
 signToActivityPubGet: true


### PR DESCRIPTION
the most useful is the meilisearch/scope, because when that's missing, nothing gets indexed!

thanks to projectmoon for noticing

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
