### PR TITLE
Thread more imports

### DIFF
--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -284,8 +284,8 @@ export class QueueService {
 	}
 
 	@bindThis
-	public createImportPleroToDbJob(user: ThinUser, targets: string[]) {
-		const jobs = targets.map(rel => this.generateToDbJobData('importPleroToDb', { user, target: rel }));
+	public createImportPleroToDbJob(user: ThinUser, targets: string[], note: MiNote['id'] | null) {
+		const jobs = targets.map(rel => this.generateToDbJobData('importPleroToDb', { user, target: rel, note }));
 		return this.dbQueue.addBulk(jobs);
 	}
 

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -278,8 +278,8 @@ export class QueueService {
 	}
 
 	@bindThis
-	public createImportMastoToDbJob(user: ThinUser, targets: string[]) {
-		const jobs = targets.map(rel => this.generateToDbJobData('importMastoToDb', { user, target: rel }));
+	public createImportMastoToDbJob(user: ThinUser, targets: string[], note: MiNote['id'] | null) {
+		const jobs = targets.map(rel => this.generateToDbJobData('importMastoToDb', { user, target: rel, note }));
 		return this.dbQueue.addBulk(jobs);
 	}
 

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -54,7 +54,7 @@ export type DbJobMap = {
 	importIGToDb: DbNoteImportToDbJobData;
 	importFBToDb: DbNoteImportToDbJobData;
 	importMastoToDb: DbNoteWithParentImportToDbJobData;
-	importPleroToDb: DbNoteImportToDbJobData;
+	importPleroToDb: DbNoteWithParentImportToDbJobData;
 	importKeyNotesToDb: DbNoteWithParentImportToDbJobData;
 	importFollowing: DbUserImportJobData;
 	importFollowingToDb: DbUserImportToDbJobData;

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -50,12 +50,12 @@ export type DbJobMap = {
 	exportUserLists: DbJobDataWithUser;
 	importAntennas: DBAntennaImportJobData;
 	importNotes: DbNoteImportJobData;
-	importTweetsToDb: DbKeyNoteImportToDbJobData;
+	importTweetsToDb: DbNoteWithParentImportToDbJobData;
 	importIGToDb: DbNoteImportToDbJobData;
 	importFBToDb: DbNoteImportToDbJobData;
-	importMastoToDb: DbNoteImportToDbJobData;
+	importMastoToDb: DbNoteWithParentImportToDbJobData;
 	importPleroToDb: DbNoteImportToDbJobData;
-	importKeyNotesToDb: DbKeyNoteImportToDbJobData;
+	importKeyNotesToDb: DbNoteWithParentImportToDbJobData;
 	importFollowing: DbUserImportJobData;
 	importFollowingToDb: DbUserImportToDbJobData;
 	importMuting: DbUserImportJobData;
@@ -113,7 +113,7 @@ export type DbNoteImportToDbJobData = {
 	target: any;
 };
 
-export type DbKeyNoteImportToDbJobData = {
+export type DbNoteWithParentImportToDbJobData = {
 	user: ThinUser;
 	target: any;
 	note: MiNote['id'] | null;


### PR DESCRIPTION
As I wrote in #177:

`recreateChain` converts a list of notes into a forest of notes, using notes that are not replies as roots, and replies as child nodes, recursively.

Previously, notes that are replies to notes not included in the export, and their children, were never put in the forest, and therefore wheren't imported.

This can be fine when importing from Twitter, or *key, since we can't really link a note to a tweet.

It's less fine when importing from Mastodon & Pleroma, because in those cases we *can* link to the remote note that the user was replying to.

This commit makes `recreateChain` optionally return "orphaned" note trees, and uses that feature when importing from Mastodon (tested) and Pleroma (should work fine).

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
